### PR TITLE
Update doc for customer about github action for app build

### DIFF
--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -133,12 +133,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - id: build-only
-        uses: enonic/release-tools/build-and-publish@master
-        with:
-          skipPublishing: true
-          repoUser: ${{ secrets.ARTIFACTORY_USERNAME }}
-          repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+      - id: build
+        uses: enonic/release-tools/action-app-build@master
       - id: deploy
         uses: enonic/action-app-deploy@main
         with:


### PR DESCRIPTION
The current github action  doc refers to build and release action script even if the release is used only by Enonic. 
For customers that need only a build action script, I added a new action script https://github.com/enonic/release-tools/tree/master/action-app-build and this is an updated doc for customers.  